### PR TITLE
Add regression test data

### DIFF
--- a/.envs/testenv.yml
+++ b/.envs/testenv.yml
@@ -30,3 +30,4 @@ dependencies:
   - pydata-sphinx-theme>=0.3.0
   - pip:
       - -e ../
+      - git+https://github.com/opensourceeconomics/lcm.git@simulation

--- a/README.md
+++ b/README.md
@@ -1,10 +1,37 @@
-# Developer Repository: Life Cycle Models
+# LCM Development Repository
 
 [![image](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/OpenSourceEconomics/lcm-dev/main.svg)](https://results.pre-commit.ci/latest/github/OpenSourceEconomics/lcm-dev/main)
 [![image](https://codecov.io/gh/OpenSourceEconomics/lcm-dev/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenSourceEconomics/lcm-dev)
 
 This repository aims to facilitate the development of the package
-[lcm](https://github.com/OpenSourceEconomics/lcm). We do so by trying to increase the
-reproducibility of insights that led to changes in `lcm` and by providing developer
-documentation, designed to explain the inner workings of the `lcm` code base.
+[lcm](https://github.com/OpenSourceEconomics/lcm). In particular, here we
+
+- Generate data that is used in the testing process of `lcm`
+- Publish the developer documentation, which is designed to explain the inner workings
+  of the `lcm` code base
+- Create graphical comparisons between `lcm` and analytical solutions
+
+## Getting Started
+
+Get started by installing the conda environment. The conda environment will contain a
+local installation of `lcm`. Therefore, we require the following directory structure:
+
+```console
+parent_folder
+ |-lcm-dev
+ |-lcm
+```
+
+Then you can install the environment using
+
+```console
+cd /path/to/lcm-dev
+mamba env create
+```
+
+and generate all data and figures by running
+
+```console
+pytask
+```

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,4 +15,6 @@ coverage:
         target: 10%
 ignore:
   - setup.py
-  - tests/**/*
+  - '**/__init__.py'
+  - '**/task_*.py'
+  - tests

--- a/environment.yml
+++ b/environment.yml
@@ -32,4 +32,4 @@ dependencies:
   - pytest-xdist
   - pip:
       - -e .
-      - git+https://github.com/opensourceeconomics/lcm.git@simulation
+      - -e ../lcm

--- a/environment.yml
+++ b/environment.yml
@@ -32,3 +32,4 @@ dependencies:
   - pytest-xdist
   - pip:
       - -e .
+      - git+https://github.com/opensourceeconomics/lcm.git@simulation

--- a/src/lcm_dev/task_regression_test.py
+++ b/src/lcm_dev/task_regression_test.py
@@ -1,4 +1,8 @@
-"""Save LCM solution and simulation output for regression testing."""
+"""Save LCM solution and simulation output for regression testing.
+
+This task needs to run again when the example model `PHELPS_DEATON` changes.
+
+"""
 import json
 
 import jax.numpy as jnp
@@ -36,7 +40,7 @@ def task_save_lcm_output(produces):
         },
     )
 
-    # Convert output to JSON seriazible format
+    # Convert output to JSON serializable format
     solution = [sol.tolist() for sol in solution]
     simulation = tree_map(lambda x: x.tolist(), simulation)
 

--- a/src/lcm_dev/task_regression_test.py
+++ b/src/lcm_dev/task_regression_test.py
@@ -1,0 +1,49 @@
+"""Save LCM solution and simulation output for regression testing."""
+import json
+
+import jax.numpy as jnp
+import pytask
+from lcm.entry_point import get_lcm_function
+from lcm.example_models import PHELPS_DEATON
+from pybaum import tree_map
+
+from lcm_dev.config import BLD
+
+
+@pytask.mark.produces(BLD.joinpath("regression_tests", "solution_and_simulation.json"))
+def task_save_lcm_output(produces):
+    model = {**PHELPS_DEATON, "n_periods": 5}
+
+    solve_model, _ = get_lcm_function(model=model, targets="solve")
+    simulate_model, _ = get_lcm_function(model=model, targets="simulate")
+
+    params = {
+        "beta": 1.0,
+        "utility": {"delta": 1.0},
+        "next_wealth": {
+            "interest_rate": 0.05,
+            "wage": 1.0,
+        },
+    }
+
+    solution = solve_model(params)
+
+    simulation = simulate_model(
+        params,
+        vf_arr_list=solution,
+        initial_states={
+            "wealth": jnp.array([1.0, 20, 40, 70]),
+        },
+    )
+
+    # Convert output to JSON seriazible format
+    solution = [sol.tolist() for sol in solution]
+    simulation = tree_map(lambda x: x.tolist(), simulation)
+
+    out = {
+        "solution": solution,
+        "simulation": simulation,
+    }
+
+    with produces.open("w") as file:
+        file.write(json.dumps(out, indent=4))


### PR DESCRIPTION
I save the `solve` and `simulate` results for the `PHELPS_DEATON` example model, which can then be used in LCM for regression testing.

**Motivation:**

Numerically testing that the LCM output agrees with the analytical solution is complex. The LCM solution might agree with the analytical solution for most wealth levels but then deviate for the first few periods for very low wealth levels. In this case, we would still be happy with the LCM solution, but it gets hard to specify a metric to allow for such deviations. Therefore, we think it might make more sense to compare the solutions graphically and test whether the output of LCM does not change using a regression test.